### PR TITLE
Serve app on trailing /, route depth > 1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
      :compiler     {:main                 my-app.core
                     :output-to            "resources/public/js/compiled/app.js"
                     :output-dir           "resources/public/js/compiled/out"
-                    :asset-path           "js/compiled/out"
+                    :asset-path           "/js/compiled/out"
                     :source-map-timestamp true
                     :preloads             [devtools.preload]
                     :external-config      {:devtools/config {:features-to-install :all}}

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="js/compiled/app.js"></script>
+    <script src="/js/compiled/app.js"></script>
     <script>my_app.core.init();</script>
   </body>
 </html>


### PR DESCRIPTION
Hey, thanks for this.

These changes serve the app when there is a trailing "/" or any subsequent path. E.g. "/about/" or "/about/anything-else/here". Previously these route patterns would cause pretty cryptic errors on the client:
```
Navigated to http://localhost:3449/about/foo
app.js:1 Uncaught SyntaxError: Unexpected token <
foo:11 Uncaught ReferenceError: my_app is not defined
    at foo:11
```
Thanks!
